### PR TITLE
Fix #2 - Typo on project's URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<version>1.0.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>kasper-analytica-server</name>
-	<url>http://analityca.kleegroup.com</url>
+	<url>http://analytica.kleegroup.com</url>
 
 	<properties>
 		<compileSource>1.6</compileSource>
@@ -146,5 +146,5 @@
 	        </plugin>
 		</plugins>
 	</build>
-	
+
 </project>


### PR DESCRIPTION
Fixed typo in URL. 

However, the provided URL is not publicly accessible.
